### PR TITLE
misc: expose global tld list to dependents

### DIFF
--- a/twistrs/src/lib.rs
+++ b/twistrs/src/lib.rs
@@ -126,4 +126,4 @@ pub mod constants;
 pub mod enrich;
 pub mod error;
 pub mod permutate;
-mod tlds;
+pub mod tlds;


### PR DESCRIPTION
Exposes the global TLD list to consumers. Helpful when wanting to perform separate filtering downstream.