### PR TITLE
Allow filtering of results via `Filter` trait

### DIFF
--- a/examples/twistrs-cli/src/main.rs
+++ b/examples/twistrs-cli/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
 
     let domain = Domain::new(matches.value_of("domain").unwrap()).unwrap();
 
-    let domain_permutations = domain.all()?.collect::<HashSet<Permutation>>();
+    let domain_permutations = domain.all().collect::<HashSet<Permutation>>();
     let domain_permutation_count = domain_permutations.len();
 
     let (tx, mut rx) = mpsc::channel(5000);

--- a/examples/twistrs-cli/src/main.rs
+++ b/examples/twistrs-cli/src/main.rs
@@ -3,6 +3,7 @@ use colored::*;
 
 use tokio::sync::mpsc;
 use twistrs::enrich::DomainMetadata;
+use twistrs::filter::Permissive;
 use twistrs::permutate::{Domain, Permutation};
 
 use anyhow::Result;
@@ -21,7 +22,7 @@ async fn main() -> Result<()> {
 
     let domain = Domain::new(matches.value_of("domain").unwrap()).unwrap();
 
-    let domain_permutations = domain.all().collect::<HashSet<Permutation>>();
+    let domain_permutations = domain.all(&Permissive).collect::<HashSet<Permutation>>();
     let domain_permutation_count = domain_permutations.len();
 
     let (tx, mut rx) = mpsc::channel(5000);

--- a/examples/twistrs-grpc/src/server.rs
+++ b/examples/twistrs-grpc/src/server.rs
@@ -5,6 +5,7 @@ use tokio::sync::mpsc;
 use tonic::{transport::Server, Request, Response, Status};
 
 use twistrs::enrich::DomainMetadata;
+use twistrs::filter::Permissive;
 use twistrs::permutate::Domain;
 
 use domain_enumeration::domain_enumeration_server::{DomainEnumeration, DomainEnumerationServer};
@@ -24,7 +25,10 @@ impl DomainEnumeration for DomainEnumerationService {
     ) -> Result<Response<Self::SendDnsResolutionStream>, Status> {
         let (tx, rx) = mpsc::channel(64);
 
-        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all() {
+        for permutation in Domain::new(&request.get_ref().fqdn)
+            .unwrap()
+            .all(&Permissive)
+        {
             let domain_metadata = DomainMetadata::new(permutation.domain.fqdn.clone());
             let mut tx = tx.clone();
 
@@ -61,7 +65,10 @@ impl DomainEnumeration for DomainEnumerationService {
     ) -> Result<Response<Self::SendMxCheckStream>, Status> {
         let (tx, rx) = mpsc::channel(64);
 
-        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all() {
+        for permutation in Domain::new(&request.get_ref().fqdn)
+            .unwrap()
+            .all(&Permissive)
+        {
             let domain_metadata = DomainMetadata::new(permutation.domain.fqdn.clone());
             let mut tx = tx.clone();
 

--- a/examples/twistrs-grpc/src/server.rs
+++ b/examples/twistrs-grpc/src/server.rs
@@ -24,7 +24,7 @@ impl DomainEnumeration for DomainEnumerationService {
     ) -> Result<Response<Self::SendDnsResolutionStream>, Status> {
         let (tx, rx) = mpsc::channel(64);
 
-        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all().unwrap() {
+        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all() {
             let domain_metadata = DomainMetadata::new(permutation.domain.fqdn.clone());
             let mut tx = tx.clone();
 
@@ -61,7 +61,7 @@ impl DomainEnumeration for DomainEnumerationService {
     ) -> Result<Response<Self::SendMxCheckStream>, Status> {
         let (tx, rx) = mpsc::channel(64);
 
-        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all().unwrap() {
+        for permutation in Domain::new(&request.get_ref().fqdn).unwrap().all() {
             let domain_metadata = DomainMetadata::new(permutation.domain.fqdn.clone());
             let mut tx = tx.clone();
 

--- a/examples/twistrs-ws/src/main.rs
+++ b/examples/twistrs-ws/src/main.rs
@@ -7,6 +7,7 @@ use std::sync::{
 
 use futures::{FutureExt, StreamExt};
 use tokio::sync::{mpsc, RwLock};
+use twistrs::filter::Permissive;
 use warp::ws::{Message, WebSocket};
 use warp::Filter;
 
@@ -93,7 +94,7 @@ async fn user_message(my_id: usize, msg: Message, users: &Users) {
             eprintln!("initiating dns resolution checks for user: {}", my_id);
 
             let domain = Domain::new(msg).unwrap();
-            let domain_permutations = domain.all().collect::<HashSet<Permutation>>();
+            let domain_permutations = domain.all(&Permissive).collect::<HashSet<Permutation>>();
 
             for v in domain_permutations.into_iter() {
                 let domain_metadata = DomainMetadata::new(v.domain.fqdn.clone());

--- a/examples/twistrs-ws/src/main.rs
+++ b/examples/twistrs-ws/src/main.rs
@@ -93,7 +93,7 @@ async fn user_message(my_id: usize, msg: Message, users: &Users) {
             eprintln!("initiating dns resolution checks for user: {}", my_id);
 
             let domain = Domain::new(msg).unwrap();
-            let domain_permutations = domain.all().unwrap().collect::<HashSet<Permutation>>();
+            let domain_permutations = domain.all().collect::<HashSet<Permutation>>();
 
             for v in domain_permutations.into_iter() {
                 let domain_metadata = DomainMetadata::new(v.domain.fqdn.clone());

--- a/twistrs/src/filter.rs
+++ b/twistrs/src/filter.rs
@@ -3,10 +3,10 @@ use crate::Domain;
 pub trait Filter {
     type Error;
 
-    fn filter(&self, domain: &Domain) -> bool;
+    fn matches(&self, domain: &Domain) -> bool;
 
-    fn try_filter(&self, domain: &Domain) -> Result<bool, Self::Error> {
-        Ok(Self::filter(self, domain))
+    fn try_matches(&self, domain: &Domain) -> Result<bool, Self::Error> {
+        Ok(Self::matches(self, domain))
     }
 }
 
@@ -16,7 +16,7 @@ pub struct Permissive;
 impl Filter for Permissive {
     type Error = ();
 
-    fn filter(&self, _: &Domain) -> bool {
+    fn matches(&self, _: &Domain) -> bool {
         true
     }
 }
@@ -35,7 +35,7 @@ impl<'a, S: AsRef<str>> Substring<'a, S> {
 impl<S: AsRef<str>> Filter for Substring<'_, S> {
     type Error = ();
 
-    fn filter(&self, domain: &Domain) -> bool {
+    fn matches(&self, domain: &Domain) -> bool {
         self.substrings
             .iter()
             .any(|s| domain.fqdn.contains(s.as_ref()))

--- a/twistrs/src/filter.rs
+++ b/twistrs/src/filter.rs
@@ -1,0 +1,35 @@
+use crate::Domain;
+
+pub trait Filter {
+    type Error;
+
+    fn filter(&self, domain: &Domain) -> bool;
+
+    fn try_filter(&self, domain: &Domain) -> Result<bool, Self::Error> {
+        Ok(Self::filter(self, domain))
+    }
+}
+
+#[derive(Default, Copy, Clone)]
+pub struct Permissive;
+
+impl Filter for Permissive {
+    type Error = ();
+
+    fn filter(&self, _: &Domain) -> bool {
+        true
+    }
+}
+
+#[derive(Default, Copy, Clone)]
+pub struct Substring<'a> {
+    pub substrings: &'a [&'a str],
+}
+
+impl Filter for Substring<'_> {
+    type Error = ();
+
+    fn filter(&self, domain: &Domain) -> bool {
+        self.substrings.iter().any(|s| domain.fqdn.contains(s))
+    }
+}

--- a/twistrs/src/filter.rs
+++ b/twistrs/src/filter.rs
@@ -1,15 +1,20 @@
 use crate::Domain;
 
+/// The `Filter` trait provides functions that allow filtering of permutations given a certain
+/// condition. This is useful when certain permutation methods (e.g.,
+/// [`tld`](./permutate/Domain#tld)) expose permutations that you would like to dismiss.
 pub trait Filter {
     type Error;
 
     fn matches(&self, domain: &Domain) -> bool;
 
+    /// **Note** &mdash; this is currently not being used internally.
     fn try_matches(&self, domain: &Domain) -> Result<bool, Self::Error> {
         Ok(Self::matches(self, domain))
     }
 }
 
+/// Open filter, all results are retained; similar to a wildcard.
 #[derive(Default, Copy, Clone)]
 pub struct Permissive;
 
@@ -21,6 +26,11 @@ impl Filter for Permissive {
     }
 }
 
+/// When passed a slice of string patterns, will filter out values that do **not** contain any of
+/// the substrings.
+///
+/// Example usage may be filtering the [`tld`](./permutate/Domain#tld) permutations to only include
+/// TLDs that contain part of the origin TLD.
 #[derive(Default, Copy, Clone)]
 pub struct Substring<'a, S: AsRef<str> + 'a> {
     substrings: &'a [S],

--- a/twistrs/src/filter.rs
+++ b/twistrs/src/filter.rs
@@ -22,14 +22,22 @@ impl Filter for Permissive {
 }
 
 #[derive(Default, Copy, Clone)]
-pub struct Substring<'a> {
-    pub substrings: &'a [&'a str],
+pub struct Substring<'a, S: AsRef<str> + 'a> {
+    substrings: &'a [S],
 }
 
-impl Filter for Substring<'_> {
+impl<'a, S: AsRef<str>> Substring<'a, S> {
+    pub fn new(substrings: &'a [S]) -> Self {
+        Self { substrings }
+    }
+}
+
+impl<S: AsRef<str>> Filter for Substring<'_, S> {
     type Error = ();
 
     fn filter(&self, domain: &Domain) -> bool {
-        self.substrings.iter().any(|s| domain.fqdn.contains(s))
+        self.substrings
+            .iter()
+            .any(|s| domain.fqdn.contains(s.as_ref()))
     }
 }

--- a/twistrs/src/lib.rs
+++ b/twistrs/src/lib.rs
@@ -18,8 +18,11 @@
 //! The following is a trivial example using [Tokio mpsc](https://docs.rs/tokio/0.2.22/tokio/sync/mpsc/index.html).
 //!
 //! ```
-//! use twistrs::enrich::DomainMetadata;
-//! use twistrs::permutate::Domain;
+//! use twistrs::{
+//!   permutate::{Domain},
+//!   enrich::DomainMetadata,
+//!   filter::{Filter, Permissive},
+//! };
 //!
 //! use tokio::sync::mpsc;
 //!
@@ -27,7 +30,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let domain = Domain::new("google.com").unwrap();
-//!     let permutations = domain.addition();
+//!     let permutations = domain.addition(&Permissive);
 //!
 //!     let (tx, mut rx) = mpsc::channel(1000);
 //!

--- a/twistrs/src/lib.rs
+++ b/twistrs/src/lib.rs
@@ -125,5 +125,8 @@ extern crate lazy_static;
 pub mod constants;
 pub mod enrich;
 pub mod error;
+pub mod filter;
 pub mod permutate;
 pub mod tlds;
+
+pub use permutate::{Domain, Permutation, PermutationError, PermutationKind};

--- a/twistrs/src/lib.rs
+++ b/twistrs/src/lib.rs
@@ -54,9 +54,7 @@
 //!         println!("{:?}", i);
 //!     }
 //! }
-//!
 //! ```
-//!
 
 #![deny(
     // TODO(jdb): Uncomment missing docs later on

--- a/twistrs/src/permutate.rs
+++ b/twistrs/src/permutate.rs
@@ -585,21 +585,14 @@ impl Domain {
     /// Permutation method that replaces all TLDs as variations of the
     /// root domain passed.
     pub fn tld(&self) -> impl Iterator<Item = Permutation> + '_ {
-        use crate::filter::{Filter, Substring};
-        let filter = Substring {
-            substrings: &["co", "gov", "uk"],
-        };
-
         TLDS.iter().filter_map(move |tld| {
             let fqdn = format!("{}.{}", &self.domain, tld);
 
             if let Ok(domain) = Domain::new(fqdn.as_str()) {
-                if filter.filter(&domain) {
-                    return Some(Permutation {
-                        domain,
-                        kind: PermutationKind::Tld,
-                    });
-                }
+                return Some(Permutation {
+                    domain,
+                    kind: PermutationKind::Tld,
+                });
             }
 
             None

--- a/twistrs/src/permutate.rs
+++ b/twistrs/src/permutate.rs
@@ -9,17 +9,20 @@
 //! Example:
 //!
 //! ```
-//! use twistrs::permutate::{Domain, Permutation};
+//! use twistrs::{
+//!   permutate::{Domain, Permutation},
+//!   filter::{Filter, Permissive},
+//! };
 //!
 //! let domain = Domain::new("google.com").unwrap();
-//! let domain_permutations: Vec<Permutation> = domain.all().expect("error permuting domains").collect();
+//! let domain_permutations: Vec<Permutation> = domain.all(&Permissive).collect();
 //! ```
 //!
 //! Additionally the permutation module can be used independently
 //! from the enrichment module.
 use crate::constants::{ASCII_LOWER, HOMOGLYPHS, KEYBOARD_LAYOUTS, MAPPED_VALUES, VOWELS};
 use crate::error::Error;
-use crate::filter::{Filter, Permissive};
+use crate::filter::Filter;
 
 use std::collections::HashSet;
 
@@ -138,27 +141,30 @@ impl Domain {
     ///
     /// Any future permutations will also be included into this function call
     /// without any changes required from any client implementations.
-    pub fn all(&self) -> impl Iterator<Item = Permutation> + '_ {
-        self.addition()
-            .chain(self.bitsquatting())
-            .chain(self.hyphentation())
-            .chain(self.insertion())
-            .chain(self.omission())
-            .chain(self.repetition())
-            .chain(self.replacement())
-            .chain(self.subdomain())
-            .chain(self.transposition())
-            .chain(self.vowel_swap())
-            .chain(self.double_vowel_insertion())
-            .chain(self.keyword())
-            .chain(self.tld())
-            .chain(self.mapped())
-            .chain(self.homoglyph())
+    pub fn all<'a>(&'a self, filter: &'a impl Filter) -> impl Iterator<Item = Permutation> + 'a {
+        self.addition(filter)
+            .chain(self.bitsquatting(filter))
+            .chain(self.hyphentation(filter))
+            .chain(self.insertion(filter))
+            .chain(self.omission(filter))
+            .chain(self.repetition(filter))
+            .chain(self.replacement(filter))
+            .chain(self.subdomain(filter))
+            .chain(self.transposition(filter))
+            .chain(self.vowel_swap(filter))
+            .chain(self.double_vowel_insertion(filter))
+            .chain(self.keyword(filter))
+            .chain(self.tld(filter))
+            .chain(self.mapped(filter))
+            .chain(self.homoglyph(filter))
     }
 
     /// Add every ASCII lowercase character between the Domain
     /// (e.g. `google`) and top-level domain (e.g. `.com`).
-    pub fn addition(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn addition<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 ASCII_LOWER
@@ -166,7 +172,7 @@ impl Domain {
                     .map(move |c| format!("{}{}.{}", self.domain, c, self.tld))
             },
             PermutationKind::Addition,
-            Permissive,
+            filter,
         )
     }
 
@@ -187,7 +193,10 @@ impl Domain {
     ///  10000000 ^ chr
     ///
     /// Then check if the resulting bit operation falls within ASCII range.
-    pub fn bitsquatting(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn bitsquatting<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn
@@ -217,13 +226,16 @@ impl Domain {
                     .flatten()
             },
             PermutationKind::Bitsquatting,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that replaces ASCII characters with multiple homoglyphs
     /// similar to the respective ASCII character.
-    pub fn homoglyph(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn homoglyph<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         // Convert the candidate into a vector of chars for proper indexing.
         Self::permutation(
             move || {
@@ -262,13 +274,16 @@ impl Domain {
                 results.into_iter()
             },
             PermutationKind::Homoglyph,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that inserts hyphens (i.e. `-`) between each
     /// character in the domain where valid.
-    pub fn hyphentation(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn hyphentation<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn.chars().skip(1).enumerate().map(move |(i, _)| {
@@ -278,14 +293,17 @@ impl Domain {
                 })
             },
             PermutationKind::Hyphenation,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that inserts specific characters that are close to
     /// any character in the domain depending on the keyboard (e.g. `Q` next
     /// to `W` in qwerty keyboard layout.
-    pub fn insertion(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn insertion<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn
@@ -310,12 +328,15 @@ impl Domain {
                     .flatten()
             },
             PermutationKind::Insertion,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that selectively removes a character from the domain.
-    pub fn omission(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn omission<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn.chars().enumerate().map(move |(i, _)| {
@@ -325,13 +346,16 @@ impl Domain {
                 })
             },
             PermutationKind::Omission,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that repeats characters twice provided they are
     /// alphabetic characters (e.g. `google.com` -> `gooogle.com`).
-    pub fn repetition(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn repetition<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn.chars().enumerate().filter_map(move |(i, c)| {
@@ -343,13 +367,16 @@ impl Domain {
                 })
             },
             PermutationKind::Repetition,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method similar to insertion, except that it replaces a given
     /// character with another character in proximity depending on keyboard layout.
-    pub fn replacement(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn replacement<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn
@@ -374,11 +401,14 @@ impl Domain {
                     .flatten()
             },
             PermutationKind::Replacement,
-            Permissive,
+            filter,
         )
     }
 
-    pub fn subdomain(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn subdomain<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn
@@ -395,13 +425,16 @@ impl Domain {
                     })
             },
             PermutationKind::Subdomain,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that swaps out characters in the domain (e.g.
     /// `google.com` -> `goolge.com`).
-    pub fn transposition(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn transposition<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn.chars().enumerate().tuple_windows().filter_map(
@@ -421,13 +454,16 @@ impl Domain {
                 )
             },
             PermutationKind::Transposition,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that swaps vowels for other vowels (e.g.
     /// `google.com` -> `gougle.com`).
-    pub fn vowel_swap(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn vowel_swap<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn
@@ -454,13 +490,16 @@ impl Domain {
                     .flatten()
             },
             PermutationKind::VowelSwap,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that inserts every lowercase ascii character between
     /// two vowels.
-    pub fn double_vowel_insertion(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn double_vowel_insertion<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 self.fqdn
@@ -481,7 +520,7 @@ impl Domain {
                     .flatten()
             },
             PermutationKind::DoubleVowelInsertion,
-            Permissive,
+            filter,
         )
     }
 
@@ -492,7 +531,10 @@ impl Domain {
     /// 2. Prepend keyword (e.g. `foo.com` -> `wordfoo.com`)
     /// 3. Append keyword and dash (e.g. `foo.com` -> `foo-word.com`)
     /// 4. Append keyword and dash (e.g. `foo.com` -> `fooword.com`)
-    pub fn keyword(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn keyword<'a>(
+        &'a self,
+        filter: &'a impl Filter,
+    ) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 KEYWORDS.iter().flat_map(move |keyword| {
@@ -506,27 +548,27 @@ impl Domain {
                 })
             },
             PermutationKind::Keyword,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that replaces all TLDs as variations of the
     /// root domain passed.
-    pub fn tld(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn tld<'a>(&'a self, filter: &'a impl Filter) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 TLDS.iter()
                     .map(move |tld| format!("{}.{}", &self.domain, tld))
             },
             PermutationKind::Mapped,
-            Permissive,
+            filter,
         )
     }
 
     /// Permutation method that maps one or more characters into another
     /// set of one or more characters that are similar, or easy to miss,
     /// such as `d` -> `cl`, `ck` -> `kk`.
-    pub fn mapped(&self) -> impl Iterator<Item = Permutation> + '_ {
+    pub fn mapped<'a>(&'a self, filter: &'a impl Filter) -> impl Iterator<Item = Permutation> + 'a {
         Self::permutation(
             move || {
                 let mut results = vec![];
@@ -549,7 +591,7 @@ impl Domain {
                 results.into_iter()
             },
             PermutationKind::Mapped,
-            Permissive,
+            filter,
         )
     }
 
@@ -559,7 +601,7 @@ impl Domain {
     fn permutation<'a, S, T: Fn() -> S + 'a, U: Filter + 'a>(
         f: T,
         kind: PermutationKind,
-        filter: U,
+        filter: &'a U,
     ) -> impl Iterator<Item = Permutation> + use<'a, S, T, U>
     where
         S: Iterator<Item = String> + 'a,
@@ -578,12 +620,14 @@ impl Domain {
 
 #[cfg(test)]
 mod tests {
+    use crate::filter::Permissive;
+
     use super::*;
 
     #[test]
     fn test_all_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = d.all().collect();
+        let permutations: Vec<_> = d.all(&Permissive).collect();
 
         assert!(!permutations.is_empty());
     }
@@ -591,7 +635,7 @@ mod tests {
     #[test]
     fn test_addition_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.addition().collect());
+        let permutations: Vec<_> = dbg!(d.addition(&Permissive).collect());
 
         assert_eq!(permutations.len(), ASCII_LOWER.len());
     }
@@ -599,7 +643,7 @@ mod tests {
     #[test]
     fn test_bitsquatting_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.bitsquatting().collect());
+        let permutations: Vec<_> = dbg!(d.bitsquatting(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -607,7 +651,7 @@ mod tests {
     #[test]
     fn test_homoglyph_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.homoglyph().collect());
+        let permutations: Vec<_> = dbg!(d.homoglyph(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -615,7 +659,7 @@ mod tests {
     #[test]
     fn test_hyphenation_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.hyphentation().collect());
+        let permutations: Vec<_> = dbg!(d.hyphentation(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -623,7 +667,7 @@ mod tests {
     #[test]
     fn test_insertion_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.insertion().collect());
+        let permutations: Vec<_> = dbg!(d.insertion(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -631,7 +675,7 @@ mod tests {
     #[test]
     fn test_omission_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.omission().collect());
+        let permutations: Vec<_> = dbg!(d.omission(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -639,7 +683,7 @@ mod tests {
     #[test]
     fn test_repetition_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.repetition().collect());
+        let permutations: Vec<_> = dbg!(d.repetition(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -647,7 +691,7 @@ mod tests {
     #[test]
     fn test_replacement_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.replacement().collect());
+        let permutations: Vec<_> = dbg!(d.replacement(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -655,7 +699,7 @@ mod tests {
     #[test]
     fn test_subdomain_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.subdomain().collect());
+        let permutations: Vec<_> = dbg!(d.subdomain(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -663,7 +707,7 @@ mod tests {
     #[test]
     fn test_transposition_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.transposition().collect());
+        let permutations: Vec<_> = dbg!(d.transposition(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -671,7 +715,7 @@ mod tests {
     #[test]
     fn test_vowel_swap_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.vowel_swap().collect());
+        let permutations: Vec<_> = dbg!(d.vowel_swap(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -679,7 +723,7 @@ mod tests {
     #[test]
     fn test_keyword_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.keyword().collect());
+        let permutations: Vec<_> = dbg!(d.keyword(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -687,7 +731,7 @@ mod tests {
     #[test]
     fn test_tld_mode() {
         let d = Domain::new("www.example.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.tld().collect());
+        let permutations: Vec<_> = dbg!(d.tld(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -695,7 +739,7 @@ mod tests {
     #[test]
     fn test_mapping_mode() {
         let d = Domain::new("www.exoock96z.com").unwrap();
-        let permutations: Vec<_> = dbg!(d.mapped().collect());
+        let permutations: Vec<_> = dbg!(d.mapped(&Permissive).collect());
 
         assert!(!permutations.is_empty());
     }
@@ -746,7 +790,7 @@ mod tests {
             .collect();
 
         for domain in domains {
-            let permutations: Vec<_> = dbg!(domain.all().collect());
+            let permutations: Vec<_> = dbg!(domain.all(&Permissive).collect());
             assert!(!permutations.is_empty());
         }
     }
@@ -757,7 +801,7 @@ mod tests {
         let expected = Domain::new("exampleivesus.com").unwrap();
 
         let results: Vec<Permutation> = domain
-            .double_vowel_insertion()
+            .double_vowel_insertion(&Permissive)
             .filter(|p| p.domain.fqdn == expected.fqdn)
             .collect();
 
@@ -775,7 +819,7 @@ mod tests {
         ];
 
         let results: Vec<Permutation> = domain
-            .tld()
+            .tld(&Permissive)
             .filter(|p| expected.contains(&p.domain.fqdn))
             .collect();
 
@@ -788,7 +832,7 @@ mod tests {
         let expected = Domain::new("trnn.com").unwrap();
 
         let results: Vec<Permutation> = domain
-            .mapped()
+            .mapped(&Permissive)
             .filter(|p| p.domain.fqdn == expected.fqdn)
             .collect();
 
@@ -798,11 +842,20 @@ mod tests {
     /// Regression test against <https://github.com/haveibeensquatted/twistrs/issues/102>
     #[test]
     fn test_irrelevant_tlds_not_being_generated() {
+        struct InnerFilter;
+        impl Filter for InnerFilter {
+            type Error = ();
+
+            fn matches(&self, domain: &Domain) -> bool {
+                domain.fqdn.contains("gov")
+            }
+        }
+
         let domain = Domain::new("www.gov.uk").unwrap();
         let unexpected = Domain::new("www.alta.no").unwrap();
 
         let results: Vec<Permutation> = domain
-            .tld()
+            .tld(&InnerFilter)
             .filter(|p| p.domain.fqdn == unexpected.fqdn)
             .collect();
 

--- a/twistrs/src/permutate.rs
+++ b/twistrs/src/permutate.rs
@@ -620,7 +620,7 @@ impl Domain {
 
 #[cfg(test)]
 mod tests {
-    use crate::filter::Permissive;
+    use crate::filter::{Permissive, Substring};
 
     use super::*;
 
@@ -860,5 +860,16 @@ mod tests {
             .collect();
 
         assert_eq!(results.len(), 0);
+    }
+
+    /// Tests that the `Substring` filter behaves as expected
+    #[test]
+    fn test_substring_default_filter() {
+        let filter = Substring::new(&["gov", "uk"]);
+        let domain = Domain::new("www.gov.uk").unwrap();
+
+        assert!(domain
+            .all(&filter)
+            .all(|p| p.domain.fqdn.contains("gov") || p.domain.fqdn.contains("uk")));
     }
 }


### PR DESCRIPTION
Add `Filter` trait with sensible default filters (`Permissive`, `Substring`)  to allow filtering of permutations generated.

Closes #102 